### PR TITLE
fix: embed correct interface in resultNumber struct

### DIFF
--- a/operation_chainable_interface_result_for_number.go
+++ b/operation_chainable_interface_result_for_number.go
@@ -12,7 +12,7 @@ type IChainableNumberResult interface {
 
 type resultNumber struct {
 	chainable *Chainable
-	IChainableBoolResult
+	IChainableNumberResult
 }
 
 type resultCount = resultNumber


### PR DESCRIPTION
The `resultNumber` struct was incorrectly embedding `IChainableBoolResult`. These interfaces are functionally identical (currently), but the correct semantic interface to embed is `IChainableNumberResult`. This change will ensure future maintainability and clarity.