### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: write
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/novalagung/gubrak/security/code-scanning/1](https://github.com/novalagung/gubrak/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/test.yml` so the token is constrained by the workflow itself instead of inherited defaults.

Best fix (without changing functionality): define workflow-level permissions with:
- `contents: write` (required for the commit step that updates `coverage.json`)
and no extra scopes.  
This keeps test/checkout/setup operations working and preserves the existing commit behavior on `master`, while still reducing risk versus implicit broad defaults.

Change location:
- In `.github/workflows/test.yml`, insert `permissions:` after the `on:` block and before `jobs:`.

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
